### PR TITLE
Added error descriptions in case the bot is unable to upload media

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,7 +210,7 @@ func download(id int, session *geddit.LoginSession, status *twitter.StatusServic
 				img, _, err = media.UploadFile(os.TempDir() + "/" + s.ID + ".gif")
 				os.Remove(os.TempDir() + "/" + s.ID + ".gif")
 				if err != nil {
-					fmt.Println("Unable to upload media!")
+					fmt.Println("Unable to upload media! Error: " + err.Error())
 					return
 				}
 			} else {
@@ -240,7 +240,7 @@ func download(id int, session *geddit.LoginSession, status *twitter.StatusServic
 				img, _, err = media.UploadFile(os.TempDir() + "/" + s.ID + ".webp")
 				os.Remove(os.TempDir() + "/" + s.ID + ".webp")
 				if err != nil {
-					fmt.Println("Unable to upload media!")
+					fmt.Println("Unable to upload media! Error: " + err.Error())
 					return
 				}
 			}
@@ -248,7 +248,7 @@ func download(id int, session *geddit.LoginSession, status *twitter.StatusServic
 			img, _, err = media.UploadFile(os.TempDir() + "/" + s.ID + ".png")
 			os.Remove(os.TempDir() + "/" + s.ID + ".png")
 			if err != nil {
-				fmt.Println("Unable to upload media!")
+				fmt.Println("Unable to upload media! Error: " + err.Error())
 				return
 			}
 		}


### PR DESCRIPTION
While setting my bots i had errors uploading media. I didn't really know what the bot expected of me so I decided to make it give me more information. That way I realized it was a Twitter auth thing.

I think it may be good that the default behavior is to give info about the problem, since bad Twitter credentials may be a common problem among users

(feel free to reject this PR)